### PR TITLE
Add DB2 support to JDBC booster

### DIFF
--- a/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
@@ -17,14 +17,39 @@ import java.util.List;
 public final class BoostProperties {
 
     public static final String DATASOURCE_DATABASE_NAME = "boost.datasource.databaseName";
+    public static final String DATASOURCE_SERVER_NAME = "boost.datasource.serverName";
+    public static final String DATASOURCE_PORT_NUMBER = "boost.datasource.portNumber";
+    public static final String DATASOURCE_USER = "boost.datasource.user";
+    public static final String DATASOURCE_PASSWORD = "boost.datasource.password";
     
+    /**
+     * Return a list of all boost properties
+     * @return
+     */
     public static List<String> getAllSupportedProperties() {
     	
     	List<String> supportedProperties = new ArrayList<String>();
     	
     	supportedProperties.add(DATASOURCE_DATABASE_NAME);
+    	supportedProperties.add(DATASOURCE_SERVER_NAME);
+    	supportedProperties.add(DATASOURCE_PORT_NUMBER);
+    	supportedProperties.add(DATASOURCE_USER);
+    	supportedProperties.add(DATASOURCE_PASSWORD);
     	
     	return supportedProperties;
+    }
+    
+    /**
+     * Return a list of all properties that need to be encrypted
+     * @return
+     */
+    public static List<String> getPropertiesToEncrypt() {
+    	
+        List<String> propertiesToEncrypt = new ArrayList<String>();
+    	
+    	propertiesToEncrypt.add(DATASOURCE_PASSWORD);
+    	
+    	return propertiesToEncrypt;
     }
     
 }

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/ConfigConstants.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/ConfigConstants.java
@@ -29,13 +29,15 @@ public final class ConfigConstants {
 
     public static final  String APPLICATION = "application";
 
-    // KeyStore configuration values
+    // KeyStore configuration element/attribute names
     public static final  String KEYSTORE = "keyStore";
-    public static final  String DEFAULT_KEYSTORE = "defaultKeyStore";
     public static final  String KEY_ENTRY = "keyEntry";
     public static final  String KEY_PASSWORD = "keyPassword";
+    
+    // KeyStore configuration values
+    public static final  String DEFAULT_KEYSTORE = "defaultKeyStore";
 
-    // Datasource configuration values
+    // Datasource configuration element/attribute names
     public static final  String DATASOURCE = "dataSource";
     public static final  String DATABASE_NAME = "databaseName";
     public static final  String JNDI_NAME = "jndiName";
@@ -44,23 +46,40 @@ public final class ConfigConstants {
     public static final  String LIBRARY_REF = "libraryRef";
     public static final  String LIBRARY = "library";
     public static final  String FILESET = "fileset";
-    public static final  String PROPERTIES_DERBY_EMBEDDED = "properties.derby.embedded";
-
-    public static final  String DEFAULT_DATASOURCE = "DefaultDataSource";
-    public static final  String DERBY_EMBEDDED = "DerbyEmbedded";
-    public static final  String DERBY_LIB = "DerbyLib";
     public static final  String CREATE_DATABASE = "createDatabase";
+    public static final  String SERVER_NAME = "serverName";
+    public static final  String PORT_NUMBER = "portNumber";
+    public static final  String PROPERTIES_DERBY_EMBEDDED = "properties.derby.embedded";
+    public static final  String PROPERTIES_DB2_JCC = "properties.db2.jcc";
+    public static final  String CONTAINER_AUTH_DATA_REF = "containerAuthDataRef";
+
+    // Datasource configuration values
+    public static final  String DEFAULT_DATASOURCE = "DefaultDataSource";
+    public static final  String DERBY_EMBEDDED_DRIVER_REF = "DerbyEmbeddedDriverRef";
+    public static final  String DERBY_LIB = "DerbyLib";
     public static final  String DERBY_DB = "DerbyDB";
+    public static final  String DB2_DRIVER_REF = "Db2DriverRef";
+    public static final  String DB2_LIB = "Db2Lib";
+    public static final  String DB2_DB = "DB2DB";
+    public static final  String DATASOURCE_AUTH_DATA = "datasourceAuth";
     
-    // General purpose configuration values
+    // Authentication configuration element/attribute names
+    public static final  String AUTH_DATA = "authData";
+    
+    // General purpose configuration element/attribute names
     public static final  String LOCATION = "location";
+    public static final  String USER = "user";
     public static final  String PASSWORD = "password";
     public static final  String TYPE = "type";
     public static final  String PROVIDER = "provider";
     public static final  String NAME = "name";
     public static final  String CONTEXT_ROOT = "context-root";
     public static final  String RESOURCES = "resources";
+    
+    // General purpose configuration values
+    public static final  String LOCALHOST = "localhost";
 
+    // Liberty features
     public static final  String SPRING_BOOT_15 = "springBoot-1.5";
     public static final  String SPRING_BOOT_20 = "springBoot-2.0";
     public static final  String SERVLET_40 = "servlet-4.0";

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
@@ -35,6 +35,8 @@ import javax.xml.transform.stream.StreamResult;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
 
+import io.openliberty.boost.common.utils.BoostUtil;
+
 /**
  * Create a Liberty server.xml
  *
@@ -42,6 +44,7 @@ import org.w3c.dom.Element;
 public class LibertyServerConfigGenerator {
 
     private String serverPath;
+    private String libertyInstallPath;
 
     private Document doc;
     private Element featureManager;
@@ -52,7 +55,10 @@ public class LibertyServerConfigGenerator {
     private Properties bootstrapProperties;
 
     public LibertyServerConfigGenerator(String serverPath) throws ParserConfigurationException {
+    	
         this.serverPath = serverPath;
+        this.libertyInstallPath = serverPath + "/../../..";  // Three directories back from 'wlp/usr/servers/BoostServer'
+        		
         generateDocument();
 
         featuresAdded = new HashSet<String>();
@@ -204,8 +210,18 @@ public class LibertyServerConfigGenerator {
     public void addBootstrapProperties(Properties properties) throws IOException {
 
     	if (properties != null) {
+    		
+    		List<String> propertiesToEncrypt = BoostProperties.getPropertiesToEncrypt();
+    		
 	        for (String key : properties.stringPropertyNames()) {
-	            String value = properties.getProperty(key);
+	        	String value;
+	        	
+	        	if (propertiesToEncrypt.contains(key)) {
+	        		value = BoostUtil.encrypt(libertyInstallPath, properties.getProperty(key));
+	        	} else {
+	                value = properties.getProperty(key);
+	        	}
+	        	
 	            bootstrapProperties.put(key, value);
 	        }
     	}

--- a/boost-common/src/main/java/io/openliberty/boost/common/utils/BoostUtil.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/utils/BoostUtil.java
@@ -11,14 +11,17 @@
 
 package io.openliberty.boost.common.utils;
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStreamReader;
 import java.util.jar.JarFile;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipInputStream;
 
+import io.openliberty.boost.common.BoostException;
 import io.openliberty.boost.common.BoostLoggerI;
 
 public class BoostUtil {
@@ -74,6 +77,39 @@ public class BoostUtil {
     
     public static String makeVariable(String propertyName) {
         return "${" + propertyName + "}";
+    }
+    
+    public static String encrypt(String libertyInstallPath, String password) throws IOException {
+    	
+    	Runtime rt = Runtime.getRuntime();
+    	String[] commands = { libertyInstallPath + "/bin/securityUtility", "encode", password };
+    	Process proc = rt.exec(commands);
+
+    	BufferedReader stdInput = new BufferedReader(new 
+    	     InputStreamReader(proc.getInputStream()));
+
+    	BufferedReader stdError = new BufferedReader(new 
+    	     InputStreamReader(proc.getErrorStream()));
+
+    	String s = null;
+    	
+    	StringBuilder out = new StringBuilder();
+    	while ((s = stdInput.readLine()) != null) {
+    	    out.append(s);
+    	}
+    	
+    	StringBuilder error = new StringBuilder();
+    	while ((s = stdError.readLine()) != null) {
+    	    error.append(s);
+    	}
+    	
+    	if (error.length() != 0) {
+    		throw new IOException("Password encryption failed: " + error);
+    	}
+    	
+    	System.out.println("Error: " + error.toString());
+    	System.out.println("ENCRYPTED PASSWORD: " + out.toString());
+    	return out.toString();
     }
 
 }

--- a/boost-common/src/main/java/io/openliberty/boost/common/utils/LibertyBoosterUtil.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/utils/LibertyBoosterUtil.java
@@ -26,8 +26,6 @@ public class LibertyBoosterUtil {
 
     public static String BOOSTER_JAXRS = "io.openliberty.boosters:jaxrs";
     public static String BOOSTER_JDBC = "io.openliberty.boosters:jdbc";
-    
-    public static String DERBY_DEPENDENCY = "org.apache.derby:derby";
 
     /**
      * take a list of pom boost dependency strings and map to liberty features for
@@ -47,13 +45,21 @@ public class LibertyBoosterUtil {
         	
         	String version = dependencies.get(BOOSTER_JDBC);
         	
-        	JDBCBoosterPackConfigurator jdbcConfig = new JDBCBoosterPackConfigurator(version, configuredBoostProperties);
-            
-            // Check for user defined derby dependency
-            if (dependencies.containsKey(DERBY_DEPENDENCY)) {
-            	String derbyVersion = dependencies.get(DERBY_DEPENDENCY);
-            	jdbcConfig.setDependency(DERBY_DEPENDENCY + ":" + derbyVersion);
+        	// Check for user defined database dependencies
+        	String configuredDatabaseDep = null;
+        	
+            if (dependencies.containsKey(JDBCBoosterPackConfigurator.DERBY_DEPENDENCY)) {
+            	String derbyVersion = dependencies.get(JDBCBoosterPackConfigurator.DERBY_DEPENDENCY);
+            	configuredDatabaseDep = JDBCBoosterPackConfigurator.DERBY_DEPENDENCY + ":" + derbyVersion;
+            	
+            } else if (dependencies.containsKey(JDBCBoosterPackConfigurator.DB2_DEPENDENCY)) {
+            	String db2Version = dependencies.get(JDBCBoosterPackConfigurator.DB2_DEPENDENCY);
+            	configuredDatabaseDep = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + db2Version;
             }
+            
+        	JDBCBoosterPackConfigurator jdbcConfig = new JDBCBoosterPackConfigurator(version, configuredBoostProperties, configuredDatabaseDep);
+            
+            
             
             boosterPackConfigList.add(jdbcConfig);
             
@@ -119,8 +125,6 @@ public class LibertyBoosterUtil {
     	for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
     		
     		if (supportedProps.contains(entry.getKey().toString())) {
-    			
-    			logger.info("Found boost property: " + entry.getKey() + ":" + entry.getValue());
     			
     			boostProperties.put(entry.getKey(), entry.getValue());
     		}

--- a/boost-common/src/test/java/io/openliberty/boost/common/config/ConfigFileUtils.java
+++ b/boost-common/src/test/java/io/openliberty/boost/common/config/ConfigFileUtils.java
@@ -58,7 +58,7 @@ public class ConfigFileUtils {
     	try {
 
     		input = new FileInputStream(bootstrapPropertiesPath);
-
+    		
     		// load a properties file
     		properties.load(input);
     		

--- a/boost-common/src/test/java/io/openliberty/boost/common/config/LibertyServerConfigGeneratorTest.java
+++ b/boost-common/src/test/java/io/openliberty/boost/common/config/LibertyServerConfigGeneratorTest.java
@@ -37,6 +37,8 @@ public class LibertyServerConfigGeneratorTest {
     @Rule
     public TemporaryFolder outputDir = new TemporaryFolder();
 
+    private final String DB2_DEPENDENCY_VERSION = "db2jcc4";
+
     /**
      * Test adding feature
      * 
@@ -54,7 +56,8 @@ public class LibertyServerConfigGeneratorTest {
 
         String serverXML = outputDir.getRoot().getAbsolutePath() + "/server.xml";
 
-        boolean featureFound = ConfigFileUtils.findStringInServerXml(serverXML, "<feature>" + SPRING_BOOT_15 + "</feature>");
+        boolean featureFound = ConfigFileUtils.findStringInServerXml(serverXML,
+                "<feature>" + SPRING_BOOT_15 + "</feature>");
 
         assertTrue("The " + SPRING_BOOT_15 + " feature was not found in the server configuration", featureFound);
 
@@ -71,9 +74,10 @@ public class LibertyServerConfigGeneratorTest {
         List<Element> featureList = getDirectChildrenByTag(featureMgr, FEATURE);
         assertEquals("Didn't find empty list of features", 0, featureList.size());
     }
-    
+
     /**
-     * Test that the EE8 JDBC version (jdbc-4.2) has been added by the JDBC booster
+     * Test that the EE8 JDBC version (jdbc-4.2) has been added by the JDBC
+     * booster
      * 
      * @throws ParserConfigurationException
      * @throws TransformerException
@@ -84,11 +88,12 @@ public class LibertyServerConfigGeneratorTest {
 
         LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
                 outputDir.getRoot().getAbsolutePath());
-        
-        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", new Properties());
-        
+
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", new Properties(),
+                null);
+
         serverConfig.addFeature(configurator.getFeature());
-        
+
         serverConfig.writeToServer();
 
         String serverXML = outputDir.getRoot().getAbsolutePath() + "/server.xml";
@@ -98,9 +103,10 @@ public class LibertyServerConfigGeneratorTest {
         assertTrue("The " + JDBC_42 + " feature was not found in the server configuration", featureFound);
 
     }
-    
+
     /**
-     * Test that the EE8 JDBC version (jdbc-4.2) has been added by the JDBC booster
+     * Test that the EE8 JDBC version (jdbc-4.2) has been added by the JDBC
+     * booster
      * 
      * @throws ParserConfigurationException
      * @throws TransformerException
@@ -111,11 +117,12 @@ public class LibertyServerConfigGeneratorTest {
 
         LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
                 outputDir.getRoot().getAbsolutePath());
-        
-        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.1-SNAPSHOT", new Properties());
-        
+
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.1-SNAPSHOT", new Properties(),
+                null);
+
         serverConfig.addFeature(configurator.getFeature());
-        
+
         serverConfig.writeToServer();
 
         String serverXML = outputDir.getRoot().getAbsolutePath() + "/server.xml";
@@ -125,7 +132,7 @@ public class LibertyServerConfigGeneratorTest {
         assertTrue("The " + JDBC_41 + " feature was not found in the server configuration", featureFound);
 
     }
-    
+
     /**
      * Test that the server is configured with the default Derby datasource
      * 
@@ -134,75 +141,316 @@ public class LibertyServerConfigGeneratorTest {
      * @throws IOException
      */
     @Test
-    public void testAddJdbcBoosterConfig_Derby() throws ParserConfigurationException, TransformerException, IOException {
+    public void testAddJdbcBoosterConfig_Derby()
+            throws ParserConfigurationException, TransformerException, IOException {
 
         LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
                 outputDir.getRoot().getAbsolutePath());
-        
-        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", new Properties());
-        
+
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", new Properties(),
+                null);
+
         serverConfig.addBoosterConfig(configurator);
-        
+
         Element serverRoot = serverConfig.getServerDoc().getDocumentElement();
-        
+
         // Check that the <library> element is correctly configured
         List<Element> libraryList = getDirectChildrenByTag(serverRoot, LIBRARY);
         assertEquals("Didn't find one and only one library", 1, libraryList.size());
-   
+
         Element library = libraryList.get(0);
         assertEquals("Library id is not correct", DERBY_LIB, library.getAttribute("id"));
-        
+
         Element fileset = getDirectChildrenByTag(library, FILESET).get(0);
         assertEquals("Fileset dir attribute is not correct", RESOURCES, fileset.getAttribute("dir"));
         assertEquals("Fileset includes attribute is not correct", "derby*.jar", fileset.getAttribute("includes"));
-        
+
         // Check that the <dataSource> element is correctly configured
         List<Element> dataSourceList = getDirectChildrenByTag(serverRoot, DATASOURCE);
         assertEquals("Didn't find one and only one dataSource", 1, dataSourceList.size());
-        
+
         Element dataSource = dataSourceList.get(0);
         assertEquals("DataSource id is not correct", DEFAULT_DATASOURCE, dataSource.getAttribute("id"));
-        assertEquals("DataSource jdbcDriverRef is not correct", DERBY_EMBEDDED, dataSource.getAttribute(JDBC_DRIVER_REF));
-        
+        assertEquals("DataSource jdbcDriverRef is not correct", DERBY_EMBEDDED_DRIVER_REF,
+                dataSource.getAttribute(JDBC_DRIVER_REF));
+
         Element propertiesDerbyEmbedded = getDirectChildrenByTag(dataSource, PROPERTIES_DERBY_EMBEDDED).get(0);
-        assertEquals("The createDatabase attribute is not correct", "create", propertiesDerbyEmbedded.getAttribute(CREATE_DATABASE));
-        assertEquals("The databaseName attribute is not correct", BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME), propertiesDerbyEmbedded.getAttribute(DATABASE_NAME));
+        assertEquals("The createDatabase attribute is not correct", "create",
+                propertiesDerbyEmbedded.getAttribute(CREATE_DATABASE));
+        assertEquals("The databaseName attribute is not correct",
+                BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME),
+                propertiesDerbyEmbedded.getAttribute(DATABASE_NAME));
 
         // Check that the <jdbcDriver> element is correctly configured
         List<Element> jdbcDriverList = getDirectChildrenByTag(serverRoot, JDBC_DRIVER);
         assertEquals("Didn't find one and only one jdbcDriver", 1, jdbcDriverList.size());
-        
+
         Element jdbcDriver = jdbcDriverList.get(0);
-        assertEquals("JdbcDriver id is not correct", DERBY_EMBEDDED, jdbcDriver.getAttribute("id"));
+        assertEquals("JdbcDriver id is not correct", DERBY_EMBEDDED_DRIVER_REF, jdbcDriver.getAttribute("id"));
         assertEquals("JdbcDriver libraryRef is not correct", DERBY_LIB, jdbcDriver.getAttribute(LIBRARY_REF));
     }
-    
+
     /**
-     * Test that the databaseName property is correctly written to bootstrap.properties
+     * Test that the server is configured with the DB2 datasource
      * 
      * @throws ParserConfigurationException
      * @throws TransformerException
      * @throws IOException
      */
     @Test
-    public void testAddJdbcBoosterConfig_with_databaseName() throws ParserConfigurationException, TransformerException, IOException {
+    public void testAddJdbcBoosterConfig_DB2() throws ParserConfigurationException, TransformerException, IOException {
 
         LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
                 outputDir.getRoot().getAbsolutePath());
-        
+
+        String db2Dependency = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + DB2_DEPENDENCY_VERSION;
+
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", new Properties(),
+                db2Dependency);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        Element serverRoot = serverConfig.getServerDoc().getDocumentElement();
+
+        // Check that the <library> element is correctly configured
+        List<Element> libraryList = getDirectChildrenByTag(serverRoot, LIBRARY);
+        assertEquals("Didn't find one and only one library", 1, libraryList.size());
+
+        Element library = libraryList.get(0);
+        assertEquals("Library id is not correct", DB2_LIB, library.getAttribute("id"));
+
+        Element fileset = getDirectChildrenByTag(library, FILESET).get(0);
+        assertEquals("Fileset dir attribute is not correct", RESOURCES, fileset.getAttribute("dir"));
+        assertEquals("Fileset includes attribute is not correct", "db2jcc*.jar", fileset.getAttribute("includes"));
+
+        // Check that the <dataSource> element is correctly configured
+        List<Element> dataSourceList = getDirectChildrenByTag(serverRoot, DATASOURCE);
+        assertEquals("Didn't find one and only one dataSource", 1, dataSourceList.size());
+
+        Element dataSource = dataSourceList.get(0);
+        assertEquals("DataSource id is not correct", DEFAULT_DATASOURCE, dataSource.getAttribute("id"));
+        assertEquals("DataSource jdbcDriverRef is not correct", DB2_DRIVER_REF,
+                dataSource.getAttribute(JDBC_DRIVER_REF));
+
+        Element propertiesDb2Jcc = getDirectChildrenByTag(dataSource, PROPERTIES_DB2_JCC).get(0);
+        assertEquals("The databaseName attribute is not correct",
+                BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME),
+                propertiesDb2Jcc.getAttribute(DATABASE_NAME));
+        assertEquals("The serverName attribute is not correct",
+                BoostUtil.makeVariable(BoostProperties.DATASOURCE_SERVER_NAME),
+                propertiesDb2Jcc.getAttribute(SERVER_NAME));
+        assertEquals("The portNumber attribute is not correct",
+                BoostUtil.makeVariable(BoostProperties.DATASOURCE_PORT_NUMBER),
+                propertiesDb2Jcc.getAttribute(PORT_NUMBER));
+
+        // Check that the <jdbcDriver> element is correctly configured
+        List<Element> jdbcDriverList = getDirectChildrenByTag(serverRoot, JDBC_DRIVER);
+        assertEquals("Didn't find one and only one jdbcDriver", 1, jdbcDriverList.size());
+
+        Element jdbcDriver = jdbcDriverList.get(0);
+        assertEquals("JdbcDriver id is not correct", DB2_DRIVER_REF, jdbcDriver.getAttribute("id"));
+        assertEquals("JdbcDriver libraryRef is not correct", DB2_LIB, jdbcDriver.getAttribute(LIBRARY_REF));
+    }
+
+    /**
+     * Test that the configured databaseName property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_databaseName_configured()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
         Properties properties = new Properties();
         properties.put(BoostProperties.DATASOURCE_DATABASE_NAME, "myDatabase");
-        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties);
-        
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties, null);
+
         serverConfig.addBoosterConfig(configurator);
-        
+
         serverConfig.writeToServer();
 
         String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
 
-        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties, BoostProperties.DATASOURCE_DATABASE_NAME);
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_DATABASE_NAME);
 
-        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_DATABASE_NAME + " is not correct", "myDatabase", propertyFound);
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_DATABASE_NAME
+                + " is not correct", "myDatabase", propertyFound);
+    }
+
+    /**
+     * Test that the default derby databaseName property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_databaseName_derby_default()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
+        Properties properties = new Properties();
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties, null);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_DATABASE_NAME);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_DATABASE_NAME
+                + " is not correct", JDBCBoosterPackConfigurator.DEFAULT_DERBY_DATABASE_NAME, propertyFound);
+    }
+
+    /**
+     * Test that the default portNumber property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_portNumber_default()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
+        String db2Dependency = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + DB2_DEPENDENCY_VERSION;
+
+        Properties properties = new Properties();
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties,
+                db2Dependency);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_PORT_NUMBER);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_PORT_NUMBER
+                + " is not correct", "50000", propertyFound);
+    }
+
+    /**
+     * Test that the configured portNumber property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_portNumber_configured()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
+        String db2Dependency = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + DB2_DEPENDENCY_VERSION;
+
+        Properties properties = new Properties();
+        properties.put(BoostProperties.DATASOURCE_PORT_NUMBER, "55555");
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties,
+                db2Dependency);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_PORT_NUMBER);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_PORT_NUMBER
+                + " is not correct", "55555", propertyFound);
+    }
+
+    /**
+     * Test that the configured serverName property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_serverName_configured()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
+        String db2Dependency = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + DB2_DEPENDENCY_VERSION;
+
+        Properties properties = new Properties();
+        properties.put(BoostProperties.DATASOURCE_SERVER_NAME, "1.1.1.1");
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties,
+                db2Dependency);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_SERVER_NAME);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_SERVER_NAME
+                + " is not correct", "1.1.1.1", propertyFound);
+    }
+
+    /**
+     * Test that the default serverName property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_serverName_default()
+            throws ParserConfigurationException, TransformerException, IOException {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath());
+
+        String db2Dependency = JDBCBoosterPackConfigurator.DB2_DEPENDENCY + ":" + DB2_DEPENDENCY_VERSION;
+
+        Properties properties = new Properties();
+        JDBCBoosterPackConfigurator configurator = new JDBCBoosterPackConfigurator("0.2-SNAPSHOT", properties,
+                db2Dependency);
+
+        serverConfig.addBoosterConfig(configurator);
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_SERVER_NAME);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_SERVER_NAME
+                + " is not correct", "localhost", propertyFound);
     }
 
 }

--- a/boost-common/src/test/java/io/openliberty/boost/common/utils/LibertyBoosterUtilTest.java
+++ b/boost-common/src/test/java/io/openliberty/boost/common/utils/LibertyBoosterUtilTest.java
@@ -49,7 +49,7 @@ public class LibertyBoosterUtilTest {
                 booster instanceof JDBCBoosterPackConfigurator);
 
         // Check that the custom databaseName is set
-        assertEquals("Database name is not correct", JDBCBoosterPackConfigurator.DEFAULT_DATABASE_NAME,
+        assertEquals("Database name is not correct", JDBCBoosterPackConfigurator.DEFAULT_DERBY_DATABASE_NAME,
                 booster.getServerProperties().getProperty(BoostProperties.DATASOURCE_DATABASE_NAME));
 
     }


### PR DESCRIPTION
This PR adds support for DB2 to the existing JDBC booster. If a db2 maven/gradle dependency is added to a project, the JDBC booster will use that as its datasource. Additionally, 4 new properties were added to support a basic default db2 type 4 connection. 