### PR TITLE
Pull dependencies from compileClasspath

### DIFF
--- a/boost-gradle/src/main/groovy/io/openliberty/boost/gradle/utils/GradleProjectUtil.groovy
+++ b/boost-gradle/src/main/groovy/io/openliberty/boost/gradle/utils/GradleProjectUtil.groovy
@@ -45,7 +45,7 @@ public class GradleProjectUtil {
         Map<String, String> dependencies = new HashMap<String, String>()
 		logger.debug("Processing project for dependencies.")
 
-        project.configurations.compile.resolvedConfiguration.resolvedArtifacts.collect { it.moduleVersion.id }.each { ModuleVersionIdentifier id ->
+        project.configurations.compileClasspath.resolvedConfiguration.resolvedArtifacts.collect { it.moduleVersion.id }.each { ModuleVersionIdentifier id ->
         	logger.debug("Found dependency while processing project: " + id.group.toString() + ":"
                     + id.name.toString() + ":" + id.version.toString())
                     


### PR DESCRIPTION
We are now searching the compileClasspath configuration for dependencies rather than just the compile configuration. The compileClasspath pulls from additional configurations including the compile configuration and the implementation configuration.

This PR fixes the issue of a missing `servlet-4.0 feature` when the `springboot-web-starter` dependency is located under the implementation configuration.

Addresses part of the problem discussed in #258 