### PR TITLE
Generic datasource property functionality

### DIFF
--- a/boost-common/src/main/java/io/openliberty/boost/common/boosters/JDBCBoosterConfig.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/boosters/JDBCBoosterConfig.java
@@ -32,8 +32,6 @@ public class JDBCBoosterConfig extends AbstractBoosterConfig {
     public static String DB2_DEPENDENCY = "com.ibm.db2.jcc:db2jcc";
 
     private static String DERBY_DEFAULT = "org.apache.derby:derby:10.14.2.0";
-    public static String DEFAULT_DERBY_DATABASE_NAME = DERBY_DB;
-    public static String DEFAULT_DB2_DATABASE_NAME = DB2_DB;
 
     private String dependency;
     private String libertyFeature;
@@ -83,44 +81,31 @@ public class JDBCBoosterConfig extends AbstractBoosterConfig {
         // Set server properties
         this.serverProperties = new Properties();
 
+        // Initialize defaults and required properties for each datasource vendor
         if (this.dependency.startsWith(DERBY_DEPENDENCY)) {
-            String databaseName = (String) boostConfigProperties.getOrDefault(BoostProperties.DATASOURCE_DATABASE_NAME,
-                    DEFAULT_DERBY_DATABASE_NAME);
-            this.serverProperties.put(BoostProperties.DATASOURCE_DATABASE_NAME, databaseName);
-
+            this.serverProperties.put(BoostProperties.DATASOURCE_DATABASE_NAME, DERBY_DB);
+            this.serverProperties.put(BoostProperties.DATASOURCE_CREATE_DATABASE, "create");
         } else if (this.dependency.startsWith(DB2_DEPENDENCY)) {
-
-            // If serverName or portNumber are not provided, use DB2's default
-            // "localhost"
-            // and "50000"
-            String serverName = (String) boostConfigProperties.getOrDefault(BoostProperties.DATASOURCE_SERVER_NAME,
-                    LOCALHOST);
-            this.serverProperties.put(BoostProperties.DATASOURCE_SERVER_NAME, serverName);
-
-            String portNumber = (String) boostConfigProperties.getOrDefault(BoostProperties.DATASOURCE_PORT_NUMBER,
-                    "50000");
-            this.serverProperties.put(BoostProperties.DATASOURCE_PORT_NUMBER, portNumber);
-
-            // For databaseName, user, and password, there is no default that
-            // would serve
-            // any purpose. The variables
-            // will be configured in the server.xml, but no values will be set
-            // in
-            // bootstrap.properties. The values will
-            // need to be passed by the user at runtime.
-            String databaseName = (String) boostConfigProperties.get(BoostProperties.DATASOURCE_DATABASE_NAME);
-            if (databaseName != null) {
-                this.serverProperties.put(BoostProperties.DATASOURCE_DATABASE_NAME, databaseName);
-            }
-
-            String user = (String) boostConfigProperties.get(BoostProperties.DATASOURCE_USER);
-            if (user != null)
-                this.serverProperties.put(BoostProperties.DATASOURCE_USER, user);
-
-            String password = (String) boostConfigProperties.get(BoostProperties.DATASOURCE_PASSWORD);
-            if (password != null) {
-                this.serverProperties.put(BoostProperties.DATASOURCE_PASSWORD, password);
-            }
+        	// For DB2, since we are expecting the database to exist, there is no
+        	// default value we can set for databaseName that would be of any use.
+        	// Likewise, for user and password, there isn't anything we could set
+        	// here that would make sense. Since these properties are required, 
+        	// set empty strings as there values to create place holders. If they 
+        	// are not overridden by the user at package time, they can be overridden
+        	// at runtime. 
+        	this.serverProperties.put(BoostProperties.DATASOURCE_DATABASE_NAME, "");
+        	this.serverProperties.put(BoostProperties.DATASOURCE_USER, "");
+        	this.serverProperties.put(BoostProperties.DATASOURCE_PASSWORD, "");
+            this.serverProperties.put(BoostProperties.DATASOURCE_SERVER_NAME, LOCALHOST);
+            this.serverProperties.put(BoostProperties.DATASOURCE_PORT_NUMBER, "50000");
+        }
+        
+        // Find and add all "boost.db." properties. This will override any default values
+        for (String key : boostConfigProperties.stringPropertyNames()) {
+        	if ( key.startsWith(BoostProperties.DATASOURCE_PREFIX)) {
+        		String value = (String) boostConfigProperties.get(key);
+        		this.serverProperties.put(key, value);
+        	}
         }
     }
 
@@ -145,16 +130,14 @@ public class JDBCBoosterConfig extends AbstractBoosterConfig {
     public void addServerConfig(Document doc) {
 
         if (dependency.startsWith(DERBY_DEPENDENCY)) {
-
-            addDerbyConfig(doc);
+        	addDatasourceConfig(doc, PROPERTIES_DERBY_EMBEDDED, DERBY_JAR);
 
         } else if (dependency.startsWith(DB2_DEPENDENCY)) {
-
-            addDb2Config(doc);
+        	addDatasourceConfig(doc, PROPERTIES_DB2_JCC, DB2_JAR);
         }
     }
 
-    private void addDerbyConfig(Document doc) {
+    private void addDatasourceConfig(Document doc, String datasourcePropertiesElement, String datasourceJar) {
 
         Element serverRoot = doc.getDocumentElement();
 
@@ -168,74 +151,51 @@ public class JDBCBoosterConfig extends AbstractBoosterConfig {
 
         // Add library
         Element lib = doc.createElement(LIBRARY);
-        lib.setAttribute("id", DERBY_LIB);
+        lib.setAttribute("id", JDBC_LIBRARY_1);
         Element fileLoc = doc.createElement(FILESET);
         fileLoc.setAttribute("dir", RESOURCES);
-        fileLoc.setAttribute("includes", "derby*.jar");
+        fileLoc.setAttribute("includes", datasourceJar);
         lib.appendChild(fileLoc);
         serverRoot.appendChild(lib);
 
         // Add datasource
         Element dataSource = doc.createElement(DATASOURCE);
         dataSource.setAttribute("id", DEFAULT_DATASOURCE);
-        dataSource.setAttribute(JDBC_DRIVER_REF, DERBY_EMBEDDED_DRIVER_REF);
+        dataSource.setAttribute(JDBC_DRIVER_REF, JDBC_DRIVER_1);
 
-        Element derbyProps = doc.createElement(PROPERTIES_DERBY_EMBEDDED);
-        derbyProps.setAttribute(DATABASE_NAME, BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME));
-        derbyProps.setAttribute(CREATE_DATABASE, "create");
-        dataSource.appendChild(derbyProps);
+        // Add all configured datasource properties
+        Element props = doc.createElement(datasourcePropertiesElement);
+        addDatasourceProperties(props);
+        dataSource.appendChild(props);
 
         serverRoot.appendChild(dataSource);
 
+        // Add jdbc driver
         Element jdbcDriver = doc.createElement(JDBC_DRIVER);
-        jdbcDriver.setAttribute("id", DERBY_EMBEDDED_DRIVER_REF);
-        jdbcDriver.setAttribute(LIBRARY_REF, DERBY_LIB);
+        jdbcDriver.setAttribute("id", JDBC_DRIVER_1);
+        jdbcDriver.setAttribute(LIBRARY_REF, JDBC_LIBRARY_1);
         serverRoot.appendChild(jdbcDriver);
-    }
-
-    private void addDb2Config(Document doc) {
-
-        Element serverRoot = doc.getDocumentElement();
-
-        // Find the root server element
-        NodeList list = doc.getChildNodes();
-        for (int i = 0; i < list.getLength(); i++) {
-            if (list.item(i).getNodeName().equals("server")) {
-                serverRoot = (Element) list.item(i);
-            }
+        
+        // Add container authentication
+        if (this.serverProperties.containsKey(BoostProperties.DATASOURCE_USER) && this.serverProperties.containsKey(BoostProperties.DATASOURCE_PASSWORD)) {
+        	dataSource.setAttribute(CONTAINER_AUTH_DATA_REF, DATASOURCE_AUTH_DATA);
+        	
+		    Element containerAuthData = doc.createElement(AUTH_DATA);
+		    containerAuthData.setAttribute("id", DATASOURCE_AUTH_DATA);
+		    containerAuthData.setAttribute(USER, BoostUtil.makeVariable(BoostProperties.DATASOURCE_USER));
+		    containerAuthData.setAttribute(PASSWORD, BoostUtil.makeVariable(BoostProperties.DATASOURCE_PASSWORD));
+		    serverRoot.appendChild(containerAuthData);
         }
-
-        // Add library
-        Element lib = doc.createElement(LIBRARY);
-        lib.setAttribute("id", DB2_LIB);
-        Element fileLoc = doc.createElement(FILESET);
-        fileLoc.setAttribute("dir", RESOURCES);
-        fileLoc.setAttribute("includes", "db2jcc*.jar");
-        lib.appendChild(fileLoc);
-        serverRoot.appendChild(lib);
-
-        // Add datasource
-        Element dataSource = doc.createElement(DATASOURCE);
-        dataSource.setAttribute("id", DEFAULT_DATASOURCE);
-        dataSource.setAttribute(JDBC_DRIVER_REF, DB2_DRIVER_REF);
-        dataSource.setAttribute(CONTAINER_AUTH_DATA_REF, DATASOURCE_AUTH_DATA);
-
-        Element db2Props = doc.createElement(PROPERTIES_DB2_JCC);
-        db2Props.setAttribute(DATABASE_NAME, BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME));
-        db2Props.setAttribute(SERVER_NAME, BoostUtil.makeVariable(BoostProperties.DATASOURCE_SERVER_NAME));
-        db2Props.setAttribute(PORT_NUMBER, BoostUtil.makeVariable(BoostProperties.DATASOURCE_PORT_NUMBER));
-        dataSource.appendChild(db2Props);
-        serverRoot.appendChild(dataSource);
-
-        Element containerAuthData = doc.createElement(AUTH_DATA);
-        containerAuthData.setAttribute("id", DATASOURCE_AUTH_DATA);
-        containerAuthData.setAttribute(USER, BoostUtil.makeVariable(BoostProperties.DATASOURCE_USER));
-        containerAuthData.setAttribute(PASSWORD, BoostUtil.makeVariable(BoostProperties.DATASOURCE_PASSWORD));
-        serverRoot.appendChild(containerAuthData);
-
-        Element jdbcDriver = doc.createElement(JDBC_DRIVER);
-        jdbcDriver.setAttribute("id", DB2_DRIVER_REF);
-        jdbcDriver.setAttribute(LIBRARY_REF, DB2_LIB);
-        serverRoot.appendChild(jdbcDriver);
+    }
+    
+    private void addDatasourceProperties(Element properties) {
+    	for (String property : this.serverProperties.stringPropertyNames()) {
+        	// We are using container authentication. Do not include user or password here
+        	if ( !property.equals(BoostProperties.DATASOURCE_USER) && !property.equals(BoostProperties.DATASOURCE_PASSWORD)) {
+        		
+        		String attribute = property.replace(BoostProperties.DATASOURCE_PREFIX, "");
+        		properties.setAttribute(attribute, BoostUtil.makeVariable(property));
+        	}
+        }
     }
 }

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
@@ -19,32 +19,17 @@ import java.util.Properties;
 import io.openliberty.boost.common.BoostLoggerI;
 
 public final class BoostProperties {
-   
+
+    // Datasource default properties
+    public static final String DATASOURCE_PREFIX = "boost.db.";
     public static final String DATASOURCE_DATABASE_NAME = "boost.db.databaseName";
     public static final String DATASOURCE_SERVER_NAME = "boost.db.serverName";
     public static final String DATASOURCE_PORT_NUMBER = "boost.db.portNumber";
     public static final String DATASOURCE_USER = "boost.db.user";
     public static final String DATASOURCE_PASSWORD = "boost.db.password";
+    public static final String DATASOURCE_CREATE_DATABASE = "boost.db.createDatabase";
+
     public static final String INTERNAL_COMPILER_TARGET = "boost.internal.compiler.target";
-
-    /**
-     * Return a list of all boost properties
-     * 
-     * @return
-     */
-    public static List<String> getAllSupportedProperties() {
-
-        List<String> supportedProperties = new ArrayList<String>();
-
-        supportedProperties.add(DATASOURCE_DATABASE_NAME);
-        supportedProperties.add(DATASOURCE_SERVER_NAME);
-        supportedProperties.add(DATASOURCE_PORT_NUMBER);
-        supportedProperties.add(DATASOURCE_USER);
-        supportedProperties.add(DATASOURCE_PASSWORD);
-        supportedProperties.add(INTERNAL_COMPILER_TARGET);
-
-        return supportedProperties;
-    }
 
     /**
      * Return a list of all properties that need to be encrypted
@@ -56,16 +41,15 @@ public final class BoostProperties {
         propertiesToEncrypt.add(DATASOURCE_PASSWORD);
         return propertiesToEncrypt;
     }
-    
+
     public static Properties getConfiguredBoostProperties(BoostLoggerI logger) {
-        List<String> supportedProps = BoostProperties.getAllSupportedProperties();
         Properties systemProperties = System.getProperties();
 
         Properties boostProperties = new Properties();
 
         for (Map.Entry<Object, Object> entry : systemProperties.entrySet()) {
 
-            if (supportedProps.contains(entry.getKey().toString())) {
+            if (entry.getKey().toString().startsWith("boost.")) {
 
                 // logger.debug("Found boost property: " + entry.getKey() + ":"
                 // + entry.getValue());

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/ConfigConstants.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/ConfigConstants.java
@@ -40,28 +40,27 @@ public final class ConfigConstants {
     // Datasource configuration element/attribute names
     public static final String DATASOURCE = "dataSource";
     public static final String DATABASE_NAME = "databaseName";
+    public static final String CREATE_DATABASE = "createDatabase";
+    public static final String SERVER_NAME = "serverName";
+    public static final String PORT_NUMBER = "portNumber";
     public static final String JNDI_NAME = "jndiName";
     public static final String JDBC_DRIVER_REF = "jdbcDriverRef";
     public static final String JDBC_DRIVER = "jdbcDriver";
     public static final String LIBRARY_REF = "libraryRef";
     public static final String LIBRARY = "library";
     public static final String FILESET = "fileset";
-    public static final String CREATE_DATABASE = "createDatabase";
-    public static final String SERVER_NAME = "serverName";
-    public static final String PORT_NUMBER = "portNumber";
     public static final String PROPERTIES_DERBY_EMBEDDED = "properties.derby.embedded";
     public static final String PROPERTIES_DB2_JCC = "properties.db2.jcc";
     public static final String CONTAINER_AUTH_DATA_REF = "containerAuthDataRef";
 
     // Datasource configuration values
     public static final String DEFAULT_DATASOURCE = "DefaultDataSource";
-    public static final String DERBY_EMBEDDED_DRIVER_REF = "DerbyEmbeddedDriverRef";
-    public static final String DERBY_LIB = "DerbyLib";
+    public static final String JDBC_DRIVER_1 = "JdbcDriver1";
+    public static final String JDBC_LIBRARY_1 = "Library1";
     public static final String DERBY_DB = "DerbyDB";
-    public static final String DB2_DRIVER_REF = "Db2DriverRef";
-    public static final String DB2_LIB = "Db2Lib";
-    public static final String DB2_DB = "DB2DB";
     public static final String DATASOURCE_AUTH_DATA = "datasourceAuth";
+    public static final String DERBY_JAR = "derby*.jar";
+    public static final String DB2_JAR = "db2jcc*.jar";
 
     // Authentication configuration element/attribute names
     public static final String AUTH_DATA = "authData";

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
@@ -217,12 +217,10 @@ public class LibertyServerConfigGenerator {
             List<String> propertiesToEncrypt = BoostProperties.getPropertiesToEncrypt();
 
             for (String key : properties.stringPropertyNames()) {
-                String value;
+                String value = properties.getProperty(key);
 
-                if (propertiesToEncrypt.contains(key)) {
-                    value = BoostUtil.encrypt(libertyInstallPath, properties.getProperty(key), logger);
-                } else {
-                    value = properties.getProperty(key);
+                if (propertiesToEncrypt.contains(key) && value != null && !value.equals("")) {
+                    value = BoostUtil.encrypt(libertyInstallPath, value, logger);
                 }
 
                 bootstrapProperties.put(key, value);

--- a/boost-common/src/test/java/io/openliberty/boost/common/boosters/JDBCBoosterTest.java
+++ b/boost-common/src/test/java/io/openliberty/boost/common/boosters/JDBCBoosterTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 
 import javax.xml.parsers.ParserConfigurationException;
 import javax.xml.transform.TransformerException;
@@ -264,7 +263,8 @@ public class JDBCBoosterTest {
     }
 
     /**
-     * Test that the server is configured with the default Derby datasource
+     * Test that the server.xml is fully configured with the default Derby
+     * datasource
      * 
      * @throws ParserConfigurationException
      * @throws TransformerException
@@ -288,11 +288,11 @@ public class JDBCBoosterTest {
         assertEquals("Didn't find one and only one library", 1, libraryList.size());
 
         Element library = libraryList.get(0);
-        assertEquals("Library id is not correct", DERBY_LIB, library.getAttribute("id"));
+        assertEquals("Library id is not correct", JDBC_LIBRARY_1, library.getAttribute("id"));
 
         Element fileset = getDirectChildrenByTag(library, FILESET).get(0);
         assertEquals("Fileset dir attribute is not correct", RESOURCES, fileset.getAttribute("dir"));
-        assertEquals("Fileset includes attribute is not correct", "derby*.jar", fileset.getAttribute("includes"));
+        assertEquals("Fileset includes attribute is not correct", DERBY_JAR, fileset.getAttribute("includes"));
 
         // Check that the <dataSource> element is correctly configured
         List<Element> dataSourceList = getDirectChildrenByTag(serverRoot, DATASOURCE);
@@ -300,11 +300,15 @@ public class JDBCBoosterTest {
 
         Element dataSource = dataSourceList.get(0);
         assertEquals("DataSource id is not correct", DEFAULT_DATASOURCE, dataSource.getAttribute("id"));
-        assertEquals("DataSource jdbcDriverRef is not correct", DERBY_EMBEDDED_DRIVER_REF,
+        assertEquals("DataSource jdbcDriverRef is not correct", JDBC_DRIVER_1,
                 dataSource.getAttribute(JDBC_DRIVER_REF));
 
-        Element propertiesDerbyEmbedded = getDirectChildrenByTag(dataSource, PROPERTIES_DERBY_EMBEDDED).get(0);
-        assertEquals("The createDatabase attribute is not correct", "create",
+        List<Element> propertiesDerbyEmbeddedList = getDirectChildrenByTag(dataSource, PROPERTIES_DERBY_EMBEDDED);
+        assertEquals("Didn't find one and only one derby embedded properties", 1, propertiesDerbyEmbeddedList.size());
+
+        Element propertiesDerbyEmbedded = propertiesDerbyEmbeddedList.get(0);
+        assertEquals("The createDatabase attribute is not correct",
+                BoostUtil.makeVariable(BoostProperties.DATASOURCE_CREATE_DATABASE),
                 propertiesDerbyEmbedded.getAttribute(CREATE_DATABASE));
         assertEquals("The databaseName attribute is not correct",
                 BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME),
@@ -315,12 +319,12 @@ public class JDBCBoosterTest {
         assertEquals("Didn't find one and only one jdbcDriver", 1, jdbcDriverList.size());
 
         Element jdbcDriver = jdbcDriverList.get(0);
-        assertEquals("JdbcDriver id is not correct", DERBY_EMBEDDED_DRIVER_REF, jdbcDriver.getAttribute("id"));
-        assertEquals("JdbcDriver libraryRef is not correct", DERBY_LIB, jdbcDriver.getAttribute(LIBRARY_REF));
+        assertEquals("JdbcDriver id is not correct", JDBC_DRIVER_1, jdbcDriver.getAttribute("id"));
+        assertEquals("JdbcDriver libraryRef is not correct", JDBC_LIBRARY_1, jdbcDriver.getAttribute(LIBRARY_REF));
     }
 
     /**
-     * Test that the server is configured with the DB2 datasource
+     * Test that the server.xml is fully configured with the DB2 datasource
      * 
      * @throws ParserConfigurationException
      * @throws TransformerException
@@ -347,11 +351,11 @@ public class JDBCBoosterTest {
         assertEquals("Didn't find one and only one library", 1, libraryList.size());
 
         Element library = libraryList.get(0);
-        assertEquals("Library id is not correct", DB2_LIB, library.getAttribute("id"));
+        assertEquals("Library id is not correct", JDBC_LIBRARY_1, library.getAttribute("id"));
 
         Element fileset = getDirectChildrenByTag(library, FILESET).get(0);
         assertEquals("Fileset dir attribute is not correct", RESOURCES, fileset.getAttribute("dir"));
-        assertEquals("Fileset includes attribute is not correct", "db2jcc*.jar", fileset.getAttribute("includes"));
+        assertEquals("Fileset includes attribute is not correct", DB2_JAR, fileset.getAttribute("includes"));
 
         // Check that the <dataSource> element is correctly configured
         List<Element> dataSourceList = getDirectChildrenByTag(serverRoot, DATASOURCE);
@@ -359,10 +363,15 @@ public class JDBCBoosterTest {
 
         Element dataSource = dataSourceList.get(0);
         assertEquals("DataSource id is not correct", DEFAULT_DATASOURCE, dataSource.getAttribute("id"));
-        assertEquals("DataSource jdbcDriverRef is not correct", DB2_DRIVER_REF,
+        assertEquals("DataSource jdbcDriverRef is not correct", JDBC_DRIVER_1,
                 dataSource.getAttribute(JDBC_DRIVER_REF));
+        assertEquals("DataSource containerAuthDataRef is not correct", DATASOURCE_AUTH_DATA,
+                dataSource.getAttribute(CONTAINER_AUTH_DATA_REF));
 
-        Element propertiesDb2Jcc = getDirectChildrenByTag(dataSource, PROPERTIES_DB2_JCC).get(0);
+        List<Element> propertiesDb2JccList = getDirectChildrenByTag(dataSource, PROPERTIES_DB2_JCC);
+        assertEquals("Didn't find one and only one derby embedded properties", 1, propertiesDb2JccList.size());
+
+        Element propertiesDb2Jcc = propertiesDb2JccList.get(0);
         assertEquals("The databaseName attribute is not correct",
                 BoostUtil.makeVariable(BoostProperties.DATASOURCE_DATABASE_NAME),
                 propertiesDb2Jcc.getAttribute(DATABASE_NAME));
@@ -378,8 +387,19 @@ public class JDBCBoosterTest {
         assertEquals("Didn't find one and only one jdbcDriver", 1, jdbcDriverList.size());
 
         Element jdbcDriver = jdbcDriverList.get(0);
-        assertEquals("JdbcDriver id is not correct", DB2_DRIVER_REF, jdbcDriver.getAttribute("id"));
-        assertEquals("JdbcDriver libraryRef is not correct", DB2_LIB, jdbcDriver.getAttribute(LIBRARY_REF));
+        assertEquals("JdbcDriver id is not correct", JDBC_DRIVER_1, jdbcDriver.getAttribute("id"));
+        assertEquals("JdbcDriver libraryRef is not correct", JDBC_LIBRARY_1, jdbcDriver.getAttribute(LIBRARY_REF));
+
+        // Check that the <containerAuthData> element is correctly configured
+        List<Element> authDataList = getDirectChildrenByTag(serverRoot, AUTH_DATA);
+        assertEquals("Didn't find one and only one authData", 1, authDataList.size());
+
+        Element authData = authDataList.get(0);
+        assertEquals("AuthData id is not correct", DATASOURCE_AUTH_DATA, authData.getAttribute("id"));
+        assertEquals("AuthData user is not correct", BoostUtil.makeVariable(BoostProperties.DATASOURCE_USER),
+                authData.getAttribute(USER));
+        assertEquals("AuthData password is not correct", BoostUtil.makeVariable(BoostProperties.DATASOURCE_PASSWORD),
+                authData.getAttribute(PASSWORD));
     }
 
     /**
@@ -442,7 +462,70 @@ public class JDBCBoosterTest {
                 BoostProperties.DATASOURCE_DATABASE_NAME);
 
         assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_DATABASE_NAME
-                + " is not correct", JDBCBoosterConfig.DEFAULT_DERBY_DATABASE_NAME, propertyFound);
+                + " is not correct", DERBY_DB, propertyFound);
+    }
+
+    /**
+     * Test that the configured createDatabase property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_createDatabase_configured() throws Exception {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath(), logger);
+
+        // Set database name property
+        System.setProperty(BoostProperties.DATASOURCE_CREATE_DATABASE, "false");
+
+        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(),
+                logger);
+
+        serverConfig.addBoosterConfig(boosters.get(0));
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_CREATE_DATABASE);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_CREATE_DATABASE
+                + " is not correct", "false", propertyFound);
+    }
+
+    /**
+     * Test that the default derby databaseName property is correctly written to
+     * bootstrap.properties
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_createDatabase_derby_default() throws Exception {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath(), logger);
+
+        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(),
+                logger);
+
+        serverConfig.addBoosterConfig(boosters.get(0));
+
+        serverConfig.writeToServer();
+
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_CREATE_DATABASE);
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_CREATE_DATABASE
+                + " is not correct", "create", propertyFound);
     }
 
     /**
@@ -579,6 +662,47 @@ public class JDBCBoosterTest {
 
         assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_SERVER_NAME
                 + " is not correct", "localhost", propertyFound);
+    }
+
+    /**
+     * Test that a configured datasource property is correctly written to
+     * bootstrap.properties and server.xml
+     * 
+     * @throws ParserConfigurationException
+     * @throws TransformerException
+     * @throws IOException
+     */
+    @Test
+    public void testAddJdbcBoosterConfig_with_generic_property() throws Exception {
+
+        LibertyServerConfigGenerator serverConfig = new LibertyServerConfigGenerator(
+                outputDir.getRoot().getAbsolutePath(), logger);
+
+        // Set database name property
+        System.setProperty(BoostProperties.DATASOURCE_PREFIX + "randomProperty", "randomValue");
+
+        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(),
+                logger);
+
+        serverConfig.addBoosterConfig(boosters.get(0));
+
+        serverConfig.writeToServer();
+
+        // Find property in bootstrap.properties
+        String bootstrapProperties = outputDir.getRoot().getAbsolutePath() + "/bootstrap.properties";
+
+        String propertyFound = ConfigFileUtils.findPropertyInBootstrapProperties(bootstrapProperties,
+                BoostProperties.DATASOURCE_PREFIX + "randomProperty");
+
+        assertEquals("The property set in bootstrap.properties for " + BoostProperties.DATASOURCE_PREFIX
+                + "randomProperty" + " is not correct", "randomValue", propertyFound);
+
+        // Find property in server.xml
+        String serverXML = outputDir.getRoot().getAbsolutePath() + "/server.xml";
+        boolean featureFound = ConfigFileUtils.findStringInServerXml(serverXML, "randomProperty=\""
+                + BoostUtil.makeVariable(BoostProperties.DATASOURCE_PREFIX + "randomProperty") + "\"");
+
+        assertTrue("The property was not found in the server configuration", featureFound);
     }
 
 }

--- a/boost-common/src/test/java/io/openliberty/boost/common/config/BoosterConfiguratorTest.java
+++ b/boost-common/src/test/java/io/openliberty/boost/common/config/BoosterConfiguratorTest.java
@@ -31,17 +31,18 @@ import io.openliberty.boost.common.utils.BoosterUtil;
 import io.openliberty.boost.common.utils.CommonLogger;
 
 public class BoosterConfiguratorTest {
-    
+
     @Rule
     public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
-    
+
     private Map<String, String> getJDBCDependency() throws BoostException {
         return BoosterUtil.createDependenciesWithBoosterAndVersion(JDBCBoosterConfig.class, "0.1-SNAPSHOT");
     }
 
     /**
      * Test that the database name property is set to the default
-     * @throws BoostException 
+     * 
+     * @throws BoostException
      * 
      */
     @Test
@@ -49,22 +50,23 @@ public class BoosterConfiguratorTest {
 
         // Get booster configurators
         BoostLoggerI logger = CommonLogger.getInstance();
-        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(), logger);
+        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(),
+                logger);
 
         // Check that the JDBCBoosterPackConfigurator was created
         AbstractBoosterConfig booster = boosters.get(0);
-        assertTrue("JDBC booster was not found in booster configurator list",
-                booster instanceof JDBCBoosterConfig);
+        assertTrue("JDBC booster was not found in booster configurator list", booster instanceof JDBCBoosterConfig);
 
         // Check that the custom databaseName is set
-        assertEquals("Database name is not correct", JDBCBoosterConfig.DEFAULT_DERBY_DATABASE_NAME,
+        assertEquals("Database name is not correct", ConfigConstants.DERBY_DB,
                 booster.getServerProperties().getProperty(BoostProperties.DATASOURCE_DATABASE_NAME));
 
     }
 
     /**
      * Test that the database name property is overridden
-     * @throws BoostException 
+     * 
+     * @throws BoostException
      * 
      */
     @Test
@@ -78,12 +80,12 @@ public class BoosterConfiguratorTest {
 
         // Get booster configurators
         BoostLoggerI logger = CommonLogger.getInstance();
-        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(), logger);
+        List<AbstractBoosterConfig> boosters = BoosterConfigurator.getBoosterPackConfigurators(getJDBCDependency(),
+                logger);
 
         // Check that the JDBCBoosterPackConfigurator was created
         AbstractBoosterConfig booster = boosters.get(0);
-        assertTrue("JDBC booster was not found in booster configurator list",
-                booster instanceof JDBCBoosterConfig);
+        assertTrue("JDBC booster was not found in booster configurator list", booster instanceof JDBCBoosterConfig);
 
         // Check that the custom databaseName is set
         assertEquals("Database name is not correct", databaseName,


### PR DESCRIPTION
This PR adds a few items:

1. Datasource properties can be added by specifying "boost.db." as a prefix. i.e. "boost.db.databaseName" or "boost.db.ssid".  This is to accommodate the configuration of any vendor specific datasource property.

2. As a result of `#1`, the "createDatabase" property is configurable. (issue #244 )

3. A Derby datasource is now configured with container authentication. 

Additionally:

1.  The jdbc configuration was compressed into one method (no longer a need to have two separate derby/db2 paths)

2. Rather than maintaining a list of boost properties, we are now just finding properties that begin with "boost.".  This was necessary to allow generic properties with the "boost.db." prefix.