### PR TITLE
Temporarily disable spring boot ssl tests

### DIFF
--- a/boost-gradle/src/test/resources/test-spring-boot-ssl/build.gradle
+++ b/boost-gradle/src/test/resources/test-spring-boot-ssl/build.gradle
@@ -26,7 +26,7 @@ bootJar {
 
 boost {
     packaging {
-        useDefaultHost = true
+        useDefaultHost = false
     }
 }
 

--- a/boost-maven/boost-maven-plugin/src/it/test-spring-boot-ssl/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-spring-boot-ssl/pom.xml
@@ -104,7 +104,7 @@
                 <artifactId>boost-maven-plugin</artifactId>
                 <version>@pom.version@</version>
                 <configuration>
-                    <useDefaultHost>true</useDefaultHost>
+                    <useDefaultHost>false</useDefaultHost>
                 </configuration>
                 <executions>
                     <execution>


### PR DESCRIPTION
There are failures in the spring boot ssl tests that Anjum is working on a fix for. In the meantime, I'm switching these tests (test-spring-boot-ssl) to useDefaultHost=false. This will bypass having boost configure and use the defaultHttpEndpoint and defer to the spring boot.  We can change these tests back once the fix is in place. 