### PR TITLE
Add http endpoint properties

### DIFF
--- a/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/BoostProperties.java
@@ -19,6 +19,11 @@ import io.openliberty.boost.common.BoostLoggerI;
 
 public final class BoostProperties {
 
+    // HTTP Endpoint properties
+    public static final String ENDPOINT_HOST = "boost.http.host";
+    public static final String ENDPOINT_HTTP_PORT = "boost.http.port";
+    public static final String ENDPOINT_HTTPS_PORT = "boost.http.securePort";
+
     // Datasource default properties
     public static final String DATASOURCE_PREFIX = "boost.db.";
     public static final String DATASOURCE_DATABASE_NAME = "boost.db.databaseName";
@@ -40,7 +45,7 @@ public final class BoostProperties {
     public static Map<String, String> getPropertiesToEncrypt() {
         Map<String, String> propertiesToEncrypt = new HashMap<String, String>();
 
-        //Add default encryption types for properties we define
+        // Add default encryption types for properties we define
         propertiesToEncrypt.put(DATASOURCE_PASSWORD, "aes");
 
         return propertiesToEncrypt;
@@ -55,8 +60,8 @@ public final class BoostProperties {
 
             if (entry.getKey().toString().startsWith("boost.")) {
 
-                // logger.debug("Found boost property: " + entry.getKey() + ":"
-                // + entry.getValue());
+                // logger.debug("Found boost property: " + 
+            	// entry.getKey() + ":" + entry.getValue());
 
                 boostProperties.put(entry.getKey(), entry.getValue());
             }

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/BoosterConfigurator.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/BoosterConfigurator.java
@@ -15,6 +15,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Properties;
 import java.util.Set;
 
 import org.reflections.Reflections;
@@ -22,6 +23,7 @@ import org.reflections.Reflections;
 import io.openliberty.boost.common.BoostException;
 import io.openliberty.boost.common.BoostLoggerI;
 import io.openliberty.boost.common.boosters.AbstractBoosterConfig;
+import io.openliberty.boost.common.utils.BoostUtil;
 
 public class BoosterConfigurator {
 
@@ -78,7 +80,26 @@ public class BoosterConfigurator {
             serverConfig.addFeature(configurator.getFeature());
             serverConfig.addBoosterConfig(configurator);
         }
-
+        
+        // Add default http endpoint configurtion and properties
+        serverConfig.addHttpEndpoint(BoostUtil.makeVariable(BoostProperties.ENDPOINT_HOST), 
+        		BoostUtil.makeVariable(BoostProperties.ENDPOINT_HTTP_PORT), 
+        		BoostUtil.makeVariable(BoostProperties.ENDPOINT_HTTPS_PORT));
+        
+        Properties endpointProperties = new Properties();
+        Properties boostConfigProperties = BoostProperties.getConfiguredBoostProperties(logger);
+        
+        String host = (String) boostConfigProperties.getOrDefault(BoostProperties.ENDPOINT_HOST, "*");
+        endpointProperties.put(BoostProperties.ENDPOINT_HOST, host);
+        
+        String http_port = (String) boostConfigProperties.getOrDefault(BoostProperties.ENDPOINT_HTTP_PORT, "9080");
+        endpointProperties.put(BoostProperties.ENDPOINT_HTTP_PORT, http_port);
+        
+        String https_port = (String) boostConfigProperties.getOrDefault(BoostProperties.ENDPOINT_HTTPS_PORT, "9443");
+        endpointProperties.put(BoostProperties.ENDPOINT_HTTPS_PORT, https_port);
+        
+        serverConfig.addBootstrapProperties(endpointProperties);
+        
         // Add war configuration is necessary
         if (!warNames.isEmpty()) {
             for (String warName : warNames) {

--- a/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
+++ b/boost-common/src/main/java/io/openliberty/boost/common/config/LibertyServerConfigGenerator.java
@@ -208,6 +208,11 @@ public class LibertyServerConfigGenerator {
                 }
             }
         }
+        
+        // Try setting all bootstrap properties to system properties for test purposes
+        for(String key : bootstrapProperties.stringPropertyNames()) {
+        	System.setProperty(key, bootstrapProperties.getProperty(key));
+        }
     }
 
     public void addBootstrapProperties(Properties properties) throws IOException {

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/invoker.properties
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/invoker.properties
@@ -1,0 +1,3 @@
+invoker.goals.1 = clean install -Dboost.http.port=9080
+#Running with different http port
+invoker.goals.2 = clean install -Dboost.http.port=9081

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/pom.xml
@@ -106,6 +106,11 @@
 							<goal>integration-test</goal>
 							<goal>verify</goal>
 						</goals>
+						<configuration>
+							<systemPropertyVariables>
+                                <test.port>${boost.http.port}</test.port>
+                            </systemPropertyVariables>
+						</configuration>
 					</execution>
 				</executions>
 			</plugin>

--- a/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/src/test/java/it/EndpointIT.java
+++ b/boost-maven/boost-maven-plugin/src/it/test-jaxrs-2.1/src/test/java/it/EndpointIT.java
@@ -22,7 +22,8 @@ public class EndpointIT {
 
     @BeforeClass
     public static void init() {
-        URL = "http://localhost:9080/api/hello";
+        String port = System.getProperty("boost.http.port");
+        URL = "http://localhost:" + port + "/api/hello";
     }
 
     @Test


### PR DESCRIPTION
1. Create properties for boost.hostname, boost.http.port, and boost.https.port.
2. Configure Liberty defaultHttpEndpoint with bootstrap variables
3. Set variables in bootstrap.properties for all three values (either user configured or default values) This allows these values to always be overridable at runtime, even if they were not configured at package time.

4. One possible limitation is in how these properties are propagated to integration tests. Currently, you can set a system property under the failsafe plugin configuration that points to boost.http.port (for example), but this value will only be set if a -Dboost.http.port is specified on "mvn package". Setting boost.http.port as a pom property doesnt seem to work, as the maven pom properties are not set as system properites, and boost will not be aware of the property to configure the server with.  This might just be a limitation with how we allow users to configure boost properties at the moment.  